### PR TITLE
Ajustes de erros no Algoritmo

### DIFF
--- a/mssql-function-foneticalize.sql
+++ b/mssql-function-foneticalize.sql
@@ -1,35 +1,31 @@
-create function dbo.foneticalize(@word varchar(255))
+--DROP function dbo.foneticalize
+ALTER function dbo.foneticalize(@word varchar(255))
     returns varchar(255) as
 BEGIN
+-- ORIGINAL: https://github.com/vyper/fonetica-sql/blob/master/mssql-function-foneticalize.sql
+-- AJUSTES FEITOS BASEADOS EM: https://github.com/sobrinho/fonetica/blob/master/lib/fonetica.rb
     DECLARE @i             int
     DECLARE @foneticalized varchar(255)
     DECLARE @letter        char(1)
-    DECLARE @specials      varchar(38)
-    DECLARE @non_specials  varchar(38)
-
+   
     set @i = 1
     set @foneticalized = ''
     set @letter = ''
-    set @specials = 'ÁÀÃÂÉÈÊÍÌÎÓÒÔÕÚÙÛÜÇáàãâéèêíìîóòôõúùûüç'
-    set @non_specials = 'AAAAEEEIIIOOOOUUUUSAAAAEEEIIIOOOOUUUUS'
-
-    -- removing especial chars
-    set @i = 1
-    while @i <= len(@specials)
-    begin
-      set @word = replace(@word, substring(@specials, @i, 2), substring(@non_specials, @i / 2, 1))
-
-      set @i = @i + 2
-    end
 
     -- uppering word
     set @word = upper(@word)
+	set @word = replace(@word, 'Ç',  'S')
+
+    -- removing especial chars
+    select  @word = @word COLLATE SQL_Latin1_General_Cp1251_CS_AS
 
     -- replace chars
     set @word = replace(@word, 'BL',  'B')
     set @word = replace(@word, 'BR',  'B')
+
     set @word = replace(@word, 'PH',  'F')
-    set @word = replace(@word, 'GL',  'G')
+    
+	SET @word = replace(@word, 'GL',  'G')
     set @word = replace(@word, 'GR',  'G')
     set @word = replace(@word, 'MG',  'G')
     set @word = replace(@word, 'NG',  'G')
@@ -72,25 +68,20 @@ BEGIN
 
     set @word = replace(@word, 'TR',  'T')
     set @word = replace(@word, 'TL',  'T')
+	
 
     set @word = replace(@word, 'CT',  'T')
     set @word = replace(@word, 'RT',  'T')
     set @word = replace(@word, 'ST',  'T')
     set @word = replace(@word, 'PT',  'T')
     set @word = replace(@word, 'RM', 'SM')
-    set @word = replace(@word, 'A',    '')
-    set @word = replace(@word, 'E',    '')
-    set @word = replace(@word, 'I',    '')
-    set @word = replace(@word, 'O',    '')
-    set @word = replace(@word, 'U',    '')
-    set @word = replace(@word, 'H',    '')
 
     -- replacing chars with regular expression: "\b[UW]" e "[MRS]\b"
     set @i = 1
     while @i <= len(@word)
     begin
       set @letter = substring(@word, @i, 1)
-
+	
       if @letter = ' '
         set @foneticalized = @foneticalized + ' '
       else if (@i = 1 or substring(@word, @i-1, 1) = ' ') and (@letter = 'W' or @letter = 'U')
@@ -103,9 +94,19 @@ BEGIN
       set @i = @i + 1
     end
 
+	set @word = @foneticalized;
+	
+	set @word = replace(@word, 'A',    '')
+    set @word = replace(@word, 'E',    '')
+    set @word = replace(@word, 'I',    '')
+    set @word = replace(@word, 'O',    '')
+    set @word = replace(@word, 'U',    '')
+    set @word = replace(@word, 'H',    '')
+
+
     -- removing repeated letters
     set @i = 1;
-    set @word = @foneticalized;
+    
     set @foneticalized = '';
     while @i <= len(@word)
     begin
@@ -123,3 +124,44 @@ BEGIN
 
     return @foneticalized
 END
+GO
+-- TESTS
+--SELECT dbo.foneticalize('ÇABIá Sábiá')
+--SELECT dbo.foneticalize('broco bloco')
+--SELECT dbo.foneticalize('casa kasa')
+--SELECT dbo.foneticalize('sela cela')
+--SELECT dbo.foneticalize('circo sirco')
+--SELECT dbo.foneticalize('coroar koroar')
+--SELECT dbo.foneticalize('cuba kuba')
+--SELECT dbo.foneticalize('roça rosa')
+--SELECT dbo.foneticalize('ameixa ameicha')
+--SELECT dbo.foneticalize('toracs torax')
+--SELECT dbo.foneticalize('compactar compatar')
+--SELECT dbo.foneticalize('fleuma fleugma')
+--SELECT dbo.foneticalize('hieroglifo hierogrifo')
+--SELECT dbo.foneticalize('negro nego')
+--SELECT dbo.foneticalize('luminar ruminar')
+--SELECT dbo.foneticalize('mudez nudez')
+--SELECT dbo.foneticalize('comendo comeno')
+--SELECT dbo.foneticalize('bunginganga bugiganga')
+--SELECT dbo.foneticalize('philipe felipe')
+--SELECT dbo.foneticalize('estupro estrupo')
+--SELECT dbo.foneticalize('queijo keijo')
+--SELECT dbo.foneticalize('lagarto largarto')
+--SELECT dbo.foneticalize('perspectiva pespectiva')
+--SELECT dbo.foneticalize('lagartixa largatixa')
+--SELECT dbo.foneticalize('mesmo mermo')
+--SELECT dbo.foneticalize('virgem virge')
+--SELECT dbo.foneticalize('supersticao superticao')
+--SELECT dbo.foneticalize('estupro estrupo')
+--SELECT dbo.foneticalize('contrato contlato')
+--SELECT dbo.foneticalize('kubitscheck kubixeque')
+--SELECT dbo.foneticalize('walter valter')
+--SELECT dbo.foneticalize('exceder esceder')
+--SELECT dbo.foneticalize('yara iara')
+--SELECT dbo.foneticalize('casa caza')
+--SELECT dbo.foneticalize('wilson uilson')
+--SELECT dbo.foneticalize('óptico ótico')
+--SELECT dbo.foneticalize('órgãozinho órgaozinho')
+--SELECT dbo.foneticalize('batista baptista')
+--SELECT dbo.foneticalize('alison allisonn')

--- a/mssql-function-foneticalize.sql
+++ b/mssql-function-foneticalize.sql
@@ -1,5 +1,5 @@
 --DROP function dbo.foneticalize
-ALTER function dbo.foneticalize(@word varchar(255))
+CREATE function dbo.foneticalize(@word varchar(255))
     returns varchar(255) as
 BEGIN
 -- ORIGINAL: https://github.com/vyper/fonetica-sql/blob/master/mssql-function-foneticalize.sql


### PR DESCRIPTION
- A palavra 'MÃE' era reduzia para '' por causa da ordem errada de substituição das vogais e do H
- Melhorada a maneira como é feita a substituição de caracteres acentuados usando collation
- Alguns testes adicionados ao final do arquivo (comentados)